### PR TITLE
Tests (pytest and visual) for PoloidalAdvectionArakawa

### DIFF
--- a/fullSimulation.py
+++ b/fullSimulation.py
@@ -133,8 +133,7 @@ def main():
         my_print(rank, nosave, "pol adv sl init done")
 
     elif poloidal_method == 'akw':
-        polAdv = PoloidalAdvectionArakawa(
-            distribFunc.eta_grid, distribFunc.getSpline(slice(1, None, -1)), constants)
+        polAdv = PoloidalAdvectionArakawa(distribFunc.eta_grid, constants)
         my_print(rank, nosave, "pol adv akw init done")
 
     else:

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -83,6 +83,9 @@ class ParallelGradient:
                 r, self._thetaVals[i], eta_grid, constants.iota, constants.R0)
 
     def getCoeffsFirstDeriv(self, n: int):
+        """
+        TODO
+        """
         b = np.zeros(n)
         b[1] = 1
 
@@ -104,6 +107,9 @@ class ParallelGradient:
         self._coeffs = solve(A, b)
 
     def _getThetaVals(self, r: float, thetaVals: np.ndarray, eta_grid: list, iota, R0):
+        """
+        TODO
+        """
         # The positions at which the spline will be evaluated are always the same.
         # They can therefore be calculated in advance
         n = eta_grid[2].size
@@ -212,6 +218,9 @@ class FluxSurfaceAdvection:
             [self._nPoints[1], self._nPoints[0], self._zLagrangePts])
 
     def _getLagrangePts(self, eta_grid: list, layout: Layout, dt: float, iota, R0):
+        """
+        TODO
+        """
         # Get z step
         dz = eta_grid[2][2]-eta_grid[2][1]
 
@@ -302,6 +311,9 @@ class FluxSurfaceAdvection:
                        self._LagrangeVals)
 
     def gridStep(self, grid: Grid):
+        """
+        TODO
+        """
         assert(grid.getLayout(grid.currentLayout).dims_order == (0, 3, 1, 2))
         for i, _ in grid.getCoords(0):  # r
             for j, _ in grid.getCoords(1):  # v

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -401,14 +401,14 @@ class VParallelAdvection:
             for j, _ in grid.getCoords(1):  # z
                 for k, _ in grid.getCoords(2):  # q
                     self.step(grid.get1DSlice(
-                        [i, j, k]), dt, parGradVals[i, j, k], r)
+                        i, j, k), dt, parGradVals[i, j, k], r)
 
     def gridStepKeepGradient(self, grid: Grid, parGradVals, dt: float):
         for i, r in grid.getCoords(0):
             for j, _ in grid.getCoords(1):  # z
                 for k, _ in grid.getCoords(2):  # q
                     self.step(grid.get1DSlice(
-                        [i, j, k]), dt, parGradVals[i, j, k], r)
+                        i, j, k), dt, parGradVals[i, j, k], r)
 
 
 class PoloidalAdvection:
@@ -727,7 +727,7 @@ class PoloidalAdvectionArakawa:
         # Do step
         for i, _ in grid.getCoords(0):  # v
             for j, _ in grid.getCoords(1):  # z
-                self.step(grid.get2DSlice([i, j]), dt, phi.get2DSlice([j]))
+                self.step(grid.get2DSlice(i, j), dt, phi.get2DSlice(j))
 
     def gridStep_SplinesUnchanged(self, grid: Grid, dt: float):
         """

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -472,7 +472,7 @@ class PoloidalAdvection:
         """
         TODO
         """
-        self._evalFunc = np.vectorize(self.evaluate, otypes=[np.float])
+        self._evalFunc = np.vectorize(self.evaluate, otypes=[float])
 
     def step(self, f: np.ndarray, dt: float, phi: Spline2D, v: float):
         """
@@ -650,6 +650,7 @@ class PoloidalAdvectionArakawa:
         self._max_loops = 0
 
         # only physically sensible option. hard-coded for now; maybe remove later
+        # boundary conditions for r direction
         self.bc = 'dirichlet'
 
     def allow_tests(self):
@@ -682,7 +683,7 @@ class PoloidalAdvectionArakawa:
         # Scaling for the coefficient in the discrete
         phi_hh /= 4 * self._dr * self._dtheta
 
-        # still np.real is used for the phi to discard imaginary values. np.real allocates new memeory -> should be replaced
+        # still np.real is used for the phi to discard imaginary values. np.real allocates new memory -> should be replaced
         J_phi = assemble_bracket('akw', self.bc,
                                  np.real(phi_hh.ravel()),
                                  self._nPoints_theta, self._nPoints_r,

--- a/pygyro/advection/test_advection.py
+++ b/pygyro/advection/test_advection.py
@@ -12,12 +12,18 @@ from ..initialisation.constants import Constants
 
 
 def gauss(x):
-    return np.exp(-x**2/4)
+    """
+    TODO
+    """
+    return np.exp(- x**2 / 4)
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize("fact,dt", [(10, 1), (10, 0.1), (5, 1)])
 def test_fluxSurfaceAdvection(fact, dt):
+    """
+    TODO
+    """
     npts = [30, 20]
     eta_vals = [np.linspace(0, 1, 4), np.linspace(0, 2*np.pi, npts[0], endpoint=False),
                 np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 1, 4)]
@@ -27,7 +33,7 @@ def test_fluxSurfaceAdvection(fact, dt):
     f_vals = np.ndarray(npts)
 
     domain = [[0, 2*np.pi], [0, 20]]
-    nkts = [n+1 for n in npts]
+    nkts = [n + 1 for n in npts]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, 3, True) for b in breaks]
     bsplines = [spl.BSplines(k, 3, True) for k in knots]
@@ -51,12 +57,15 @@ def test_fluxSurfaceAdvection(fact, dt):
     for n in range(N):
         fluxAdv.step(f_vals, 0)
 
-    assert(np.max(np.abs(f_vals-f_end)) < 1e-4)
+    assert(np.max(np.abs(f_vals - f_end)) < 1e-4)
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize("nptZ,dt,err", [(32, 1.0, 1.5e-2), (64, 0.5, 3e-4), (128, 0.25, 1e-5)])
 def test_fluxSurfaceAdvectionAligned(nptZ, dt, err):
+    """
+    TODO
+    """
     npts = [nptZ, nptZ]
 
     constants = Constants()
@@ -71,7 +80,7 @@ def test_fluxSurfaceAdvectionAligned(nptZ, dt, err):
     f_vals = np.ndarray(npts)
 
     domain = [[0, 2*np.pi], [0, 2*np.pi*constants.R0]]
-    nkts = [n+1 for n in npts]
+    nkts = [n + 1 for n in npts]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, 3, True) for b in breaks]
     bsplines = [spl.BSplines(k, 3, True) for k in knots]
@@ -89,21 +98,24 @@ def test_fluxSurfaceAdvectionAligned(nptZ, dt, err):
 
     m, n = (5, -4)
     theta = eta_grids[0]
-    phi = eta_grids[1]*2*np.pi/domain[1][1]
-    f_vals[:, :] = np.sin(m*theta[:, None] + n*phi[None, :])
+    phi = eta_grids[1] * 2*np.pi / domain[1][1]
+    f_vals[:, :] = np.sin(m*theta[:, None] + n * phi[None, :])
 
     # ~ f_vals[:,:] = np.sin(eta_vals[2]*np.pi/fact)
     f_end = f_vals.copy()
 
     for n in range(N):
         fluxAdv.step(f_vals, 0)
-    #~ print(np.max(np.abs(f_vals-f_end)))
+    # ~ print(np.max(np.abs(f_vals-f_end)))
     assert(np.max(np.abs(f_vals-f_end)) < err)
 
 
 @pytest.mark.serial
 @pytest.mark.parametrize("function,N", [(gauss, 10), (gauss, 20), (gauss, 30)])
 def test_vParallelAdvection(function, N):
+    """
+    TODO
+    """
     npts = 50
     f = np.empty(npts)
 
@@ -112,7 +124,7 @@ def test_vParallelAdvection(function, N):
     dt = 0.1
     c = 2.0
 
-    nkts = npts-2
+    nkts = npts - 2
     breaks = np.linspace(-5, 5, num=nkts)
     knots = spl.make_knots(breaks, 3, False)
     spline = spl.BSplines(knots, 3, False)
@@ -136,7 +148,7 @@ def test_vParallelAdvection(function, N):
     fEnd = np.empty(npts)
 
     for i in range(npts):
-        if ((x[i]-c*dt*N) < x[0]):
+        if ((x[i] - c * dt * N) < x[0]):
             fEnd[i] = fEq(r, (x[i]-c*dt*N), constants.CN0, constants.kN0, constants.deltaRN0,
                           constants.rp, constants.CTi, constants.kTi, constants.deltaRTi)
         else:
@@ -148,6 +160,9 @@ def test_vParallelAdvection(function, N):
 @pytest.mark.serial
 @pytest.mark.parametrize("N", [10, 20, 30])
 def test_vParallelAdvectionPeriodic(N):
+    """
+    TODO
+    """
     npts = 50
     f = np.empty(npts)
 
@@ -174,22 +189,28 @@ def test_vParallelAdvectionPeriodic(N):
     fEnd = np.empty(npts)
 
     for i in range(npts):
-        fEnd[i] = gauss((x[i]-c*dt*N+5) % 10 - 5)
+        fEnd[i] = gauss((x[i] - c * dt * N + 5) % 10 - 5)
 
-    assert(max(abs(f-fEnd)) < 2e-3)
+    assert(max(abs(f - fEnd)) < 2e-3)
 
 
 def Phi(r, theta, omega, xc, yc):
-    return omega * (r*r/2 - r*np.sin(theta)*yc - r * np.cos(theta)*xc)
+    """
+    TODO
+    """
+    return omega * (r * r / 2 - r * np.sin(theta) * yc - r * np.cos(theta) * xc)
 
 
 def initConditions(r, theta):
+    """
+    TODO
+    """
     a = 2
-    factor = np.pi/a/2
-    r = np.sqrt((r-8)**2+8*(theta-np.pi)**2)
+    factor = np.pi / (2 * a)
+    r = np.sqrt((r - 8)**2 + 8 * (theta - np.pi)**2)
 
     if (r <= a):
-        return np.cos(r*factor)**4
+        return np.cos(r * factor)**4
     else:
         return 0.0
 
@@ -200,12 +221,15 @@ initConds = np.vectorize(initConditions, otypes=[float])
 @pytest.mark.serial
 @pytest.mark.parametrize("dt,v,xc,yc", [(1.0, -5.0, 0, 0), (0.1, 5.0, 1, 0), (0.1, 2.0, 2, 1)])
 def test_poloidalAdvection(dt, v, xc, yc):
+    """
+    TODO
+    """
 
     npts = [64, 64]
     eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*np.pi, npts[0], endpoint=False),
                 np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
 
-    N = int(1/dt)
+    N = int(1 / dt)
 
     f_vals = np.ndarray([npts[1], npts[0]])
     final_f_vals = np.ndarray([npts[1], npts[0]])
@@ -215,7 +239,7 @@ def test_poloidalAdvection(dt, v, xc, yc):
 
     domain = [[1, 14.5], [0, 2*np.pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -253,8 +277,8 @@ def test_poloidalAdvection(dt, v, xc, yc):
     finalPts[1][:] = np.sqrt(x * x + y * y)
     final_f_vals[:, :] = initConds(finalPts[1], finalPts[0])
 
-    l2 = np.sqrt(trapz(trapz((f_vals-final_f_vals)**2,
-                 eta_grids[1], axis=0)*eta_grids[0], eta_grids[0]))
+    l2 = np.sqrt(trapz(trapz((f_vals - final_f_vals)**2,
+                 eta_grids[1], axis=0) * eta_grids[0], eta_grids[0]))
     assert(l2 < 0.2)
 
 
@@ -262,6 +286,9 @@ def test_poloidalAdvection(dt, v, xc, yc):
 @pytest.mark.long
 @pytest.mark.parametrize("dt,v,xc,yc", [(1.0, -5.0, 0, 0), (0.1, 5.0, 1, 0), (0.1, 2.0, 2, 1)])
 def test_poloidalAdvectionImplicit(dt, v, xc, yc):
+    """
+    TODO
+    """
 
     npts = [64, 64]
     eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*np.pi, npts[0], endpoint=False),
@@ -277,7 +304,7 @@ def test_poloidalAdvectionImplicit(dt, v, xc, yc):
 
     domain = [[1, 14.5], [0, 2*np.pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -316,13 +343,16 @@ def test_poloidalAdvectionImplicit(dt, v, xc, yc):
     finalPts[1][:] = np.sqrt(x * x + y * y)
     final_f_vals[:, :] = initConds(finalPts[1], finalPts[0])
 
-    l2 = np.sqrt(trapz(trapz((f_vals-final_f_vals)**2,
-                 eta_grids[1], axis=0)*eta_grids[0], eta_grids[0]))
+    l2 = np.sqrt(trapz(trapz((f_vals - final_f_vals)**2,
+                 eta_grids[1], axis=0) * eta_grids[0], eta_grids[0]))
     assert(l2 < 0.2)
 
 
 @pytest.mark.serial
 def test_fluxSurfaceAdvection_gridIntegration():
+    """
+    TODO
+    """
     npts = [10, 20, 10, 10]
     grid, constants, _ = setupCylindricalGrid(npts=npts,
                                               layout='flux_surface')
@@ -339,6 +369,9 @@ def test_fluxSurfaceAdvection_gridIntegration():
 
 @pytest.mark.serial
 def test_vParallelAdvection_gridIntegration():
+    """
+    TODO
+    """
     npts = [4, 4, 4, 100]
     grid, constants, _ = setupCylindricalGrid(npts=npts,
                                               layout='v_parallel')
@@ -360,6 +393,9 @@ def test_vParallelAdvection_gridIntegration():
 
 @pytest.mark.serial
 def test_poloidalAdvection_gridIntegration():
+    """
+    TODO
+    """
     npts = [10, 20, 10, 10]
     grid, constants, _ = setupCylindricalGrid(npts=npts,
                                               layout='poloidal')
@@ -387,129 +423,137 @@ def test_poloidalAdvection_gridIntegration():
 def test_equilibrium():
     comm = MPI.COMM_WORLD
 
-    npts = [20,20,10,8]
-    grid,constants,_ = setupCylindricalGrid(npts   = npts,
-                                layout = 'flux_surface',
-                                eps    = 0.0,
-                                comm   = comm)
+    npts = [20, 20, 10, 8]
+    grid, constants, _ = setupCylindricalGrid(npts=npts,
+                                layout='flux_surface',
+                                eps=0.0,
+                                comm=comm)
 
     startVals = grid._f.copy()
 
-    N=10
+    N = 10
 
-    dt=0.1
-    halfStep = dt*0.5
+    dt = 0.1
+    halfStep = dt * 0.5
 
-    fluxAdv = FluxSurfaceAdvection(grid.eta_grid, grid.get2DSpline(),grid.getLayout('flux_surface'),halfStep)
+    fluxAdv = FluxSurfaceAdvection(
+        grid.eta_grid, grid.get2DSpline(), grid.getLayout('flux_surface'), halfStep)
     vParAdv = VParallelAdvection(grid.eta_grid, grid.getSpline(3))
-    polAdv = PoloidalAdvection(grid.eta_grid, grid.getSpline(slice(1,None,-1)))
+    polAdv = PoloidalAdvection(
+        grid.eta_grid, grid.getSpline(slice(1, None, -1)))
 
-    phi = spl.Spline2D(grid.getSpline(1),grid.getSpline(0))
-    phiVals = np.empty([npts[1],npts[0]])
-    phiVals[:]=3*grid.eta_grid[0]**2
-    interp = spl.SplineInterpolator2D(grid.getSpline(1),grid.getSpline(0))
+    phi = spl.Spline2D(grid.getSpline(1), grid.getSpline(0))
+    phiVals = np.empty([npts[1], npts[0]])
+    phiVals[:] = 3 * grid.eta_grid[0]**2
+    interp = spl.SplineInterpolator2D(grid.getSpline(1), grid.getSpline(0))
 
-    interp.compute_interpolant(phiVals,phi)
+    interp.compute_interpolant(phiVals, phi)
 
     for n in range(N):
-        for i,_ in grid.getCoords(0): # r
-            for j,_ in grid.getCoords(1): # v
-                fluxAdv.step(grid.get2DSlice([i,j]),j)
+        for i, _ in grid.getCoords(0):  # r
+            for j, _ in grid.getCoords(1):  # v
+                fluxAdv.step(grid.get2DSlice([i, j]), j)
 
         grid.setLayout('v_parallel')
 
-        for i,r in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                for k,_ in grid.getCoords(2): # q
-                    vParAdv.step(grid.get1DSlice([i,j,k]),halfStep,0,r)
+        for i, r in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                for k, _ in grid.getCoords(2):  # q
+                    vParAdv.step(grid.get1DSlice([i, j, k]), halfStep, 0, r)
 
         grid.setLayout('poloidal')
 
-        for i,v in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                polAdv.step(grid.get2DSlice([i,j]),dt,phi,v)
+        for i, v in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                polAdv.step(grid.get2DSlice([i, j]), dt, phi, v)
 
         grid.setLayout('v_parallel')
 
-        for i,r in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                for k,_ in grid.getCoords(2): # q
-                    vParAdv.step(grid.get1DSlice([i,j,k]),halfStep,0,r)
+        for i, r in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                for k, _ in grid.getCoords(2):  # q
+                    vParAdv.step(grid.get1DSlice([i, j, k]), halfStep, 0, r)
 
         grid.setLayout('flux_surface')
 
-        for i,_ in grid.getCoords(0): # r
-            for j,_ in grid.getCoords(1): # v
-                fluxAdv.step(grid.get2DSlice([i,j]),j)
+        for i, _ in grid.getCoords(0):  # r
+            for j, _ in grid.getCoords(1):  # v
+                fluxAdv.step(grid.get2DSlice([i, j]), j)
 
     print(np.max(startVals-grid._f))
-    assert(np.max(startVals-grid._f)<1e-8)
+    assert(np.max(startVals-grid._f) < 1e-8)
+
 
 @pytest.mark.parallel
 def test_perturbedEquilibrium():
     comm = MPI.COMM_WORLD
 
-    npts = [20,20,10,8]
-    grid,constants,_ = setupCylindricalGrid(npts   = npts,
-                                layout = 'flux_surface',
-                                comm   = comm)
+    npts = [20, 20, 10, 8]
+    grid, constants, _ = setupCylindricalGrid(npts=npts,
+                                layout='flux_surface',
+                                comm=comm)
 
     startVals = grid._f.copy()
 
-    N=10
+    N = 10
 
-    dt=0.1
-    halfStep = dt*0.5
+    dt = 0.1
+    halfStep = dt * 0.5
 
-    fluxAdv = FluxSurfaceAdvection(grid.eta_grid, grid.get2DSpline(),grid.getLayout('flux_surface'),halfStep)
+    fluxAdv = FluxSurfaceAdvection(
+        grid.eta_grid, grid.get2DSpline(), grid.getLayout('flux_surface'), halfStep)
     vParAdv = VParallelAdvection(grid.eta_grid, grid.getSpline(3))
-    polAdv = PoloidalAdvection(grid.eta_grid, grid.getSpline(slice(1,None,-1)))
+    polAdv = PoloidalAdvection(
+        grid.eta_grid, grid.getSpline(slice(1, None, -1)))
 
-    phi = spl.Spline2D(grid.getSpline(1),grid.getSpline(0))
-    phiVals = np.empty([npts[1],npts[0]])
-    phiVals[:]=3*grid.eta_grid[0]**2
-    interp = spl.SplineInterpolator2D(grid.getSpline(1),grid.getSpline(0))
+    phi = spl.Spline2D(grid.getSpline(1), grid.getSpline(0))
+    phiVals = np.empty([npts[1], npts[0]])
+    phiVals[:] = 3 * grid.eta_grid[0]**2
+    interp = spl.SplineInterpolator2D(grid.getSpline(1), grid.getSpline(0))
 
-    interp.compute_interpolant(phiVals,phi)
+    interp.compute_interpolant(phiVals, phi)
 
     for n in range(N):
-        for i,_ in grid.getCoords(0): # r
-            for j,_ in grid.getCoords(1): # v
-                fluxAdv.step(grid.get2DSlice([i,j]),j)
+        for i, _ in grid.getCoords(0):  # r
+            for j, _ in grid.getCoords(1):  # v
+                fluxAdv.step(grid.get2DSlice([i, j]), j)
 
         grid.setLayout('v_parallel')
 
-        for i,r in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                for k,_ in grid.getCoords(2): # q
-                    vParAdv.step(grid.get1DSlice([i,j,k]),halfStep,0,r)
+        for i, r in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                for k, _ in grid.getCoords(2):  # q
+                    vParAdv.step(grid.get1DSlice([i, j, k]), halfStep, 0, r)
 
         grid.setLayout('poloidal')
 
-        for i,v in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                polAdv.step(grid.get2DSlice([i,j]),dt,phi,v)
+        for i, v in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                polAdv.step(grid.get2DSlice([i, j]), dt, phi, v)
 
         grid.setLayout('v_parallel')
 
-        for i,r in grid.getCoords(0):
-            for j,_ in grid.getCoords(1): # z
-                for k,_ in grid.getCoords(2): # q
-                    vParAdv.step(grid.get1DSlice([i,j,k]),halfStep,0,r)
+        for i, r in grid.getCoords(0):
+            for j, _ in grid.getCoords(1):  # z
+                for k, _ in grid.getCoords(2):  # q
+                    vParAdv.step(grid.get1DSlice([i, j, k]), halfStep, 0, r)
 
         grid.setLayout('flux_surface')
 
-        for i,_ in grid.getCoords(0): # r
-            for j,_ in grid.getCoords(1): # v
-                fluxAdv.step(grid.get2DSlice([i,j]),j)
+        for i, _ in grid.getCoords(0):  # r
+            for j, _ in grid.getCoords(1):  # v
+                fluxAdv.step(grid.get2DSlice([i, j]), j)
 
     print(np.max(startVals-grid._f))
-    assert(np.max(startVals-grid._f)>1e-8)
+    assert(np.max(startVals-grid._f) > 1e-8)
 """
 
 
 @pytest.mark.serial
 def test_vParGradAligned():
+    """
+    TODO
+    """
     comm = MPI.COMM_WORLD
 
     npts = [20, 80, 20, 8]
@@ -529,8 +573,8 @@ def test_vParGradAligned():
 
     m, n = (5, -4)
     theta = grid.eta_grid[1]
-    phi = grid.eta_grid[2]*2*np.pi/constants.zMax
-    phiVals[:, :] = np.sin(m*theta[None, :] + n*phi[:, None])
+    phi = grid.eta_grid[2] * 2*np.pi / constants.zMax
+    phiVals[:, :] = np.sin(m * theta[None, :] + n * phi[:, None])
 
     der = np.empty([npts[2], npts[1]])
     pG.parallel_gradient(phiVals, 0, der)
@@ -540,6 +584,9 @@ def test_vParGradAligned():
 
 @pytest.mark.serial
 def test_vParGrad():
+    """
+    TODO
+    """
     comm = MPI.COMM_WORLD
 
     npts = [20, 20, 10, 8]
@@ -563,19 +610,29 @@ def test_vParGrad():
 
 
 def pg_Phi(theta, z):
+    """
+    TODO
+    """
     # return np.cos(z*np.pi*0.1) + np.sin(theta)
-    return np.sin(z*np.pi*0.1)**2 + np.cos(theta)**2
+    return np.sin(z * np.pi * 0.1)**2 + np.cos(theta)**2
 
 
 def pg_dPhi(r, theta, z, btheta, bz):
+    """
+    TODO
+    """
     # return -np.sin(z*np.pi*0.1)*np.pi*0.1*bz + np.cos(theta)*btheta
-    return 2*np.sin(z*np.pi*0.1)*np.cos(z*np.pi*0.1)*np.pi*0.1*bz - 2*np.cos(theta)*np.sin(theta)*btheta/r
+    return 2 * np.sin(z * np.pi * 0.1) * np.cos(z * np.pi * 0.1) * np.pi * 0.1 * bz \
+        - 2 * np.cos(theta) * np.sin(theta) * btheta / r
 
 
 @pytest.mark.serial
 @pytest.mark.long
 @pytest.mark.parametrize("phiOrder,zOrder", [(3, 3), (3, 4), (3, 5), (4, 4)])
 def test_Phi_deriv_dz(phiOrder, zOrder):
+    """
+    TODO
+    """
     nconvpts = 2
     npts = [1, 64, 64]
 

--- a/pygyro/advection/test_advection.py
+++ b/pygyro/advection/test_advection.py
@@ -569,7 +569,7 @@ def test_poloidalAdvectionArakawa_gridIntegration():
 
     for i, _ in grid.getCoords(0):  # z
         for j, _ in grid.getCoords(1):
-            grid_points = grid.get2DSlice([i, j])
+            grid_points = grid.get2DSlice(i, j)
             polAdv.step(grid_points, dt, np.array(phiVals, dtype=float))
 
 

--- a/pygyro/advection/visual_test_advection.py
+++ b/pygyro/advection/visual_test_advection.py
@@ -327,6 +327,7 @@ def test_poloidalAdvection_vortex():
         fig.canvas.draw()
         fig.canvas.flush_events()
 
+
 @pytest.mark.serial
 def test_poloidalAdvectionArakawa_vortex():
     """

--- a/pygyro/advection/visual_test_advection.py
+++ b/pygyro/advection/visual_test_advection.py
@@ -10,11 +10,14 @@ from ..initialisation.setups import setupCylindricalGrid
 from ..initialisation.constants import get_constants
 from ..initialisation.initialiser_funcs import f_eq
 from ..model.layout import Layout
-from .advection import FluxSurfaceAdvection, PoloidalAdvection, VParallelAdvection, ParallelGradient
+from .advection import FluxSurfaceAdvection, PoloidalAdvection, PoloidalAdvectionArakawa, VParallelAdvection, ParallelGradient
 
 
 @pytest.mark.serial
 def test_fluxSurfaceAdvection():
+    """
+    TODO
+    """
     npts = [30, 20]
     eta_vals = [np.linspace(0, 1, 4), np.linspace(0, 2*pi, npts[0], endpoint=False),
                 np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 1, 4)]
@@ -25,10 +28,10 @@ def test_fluxSurfaceAdvection():
 
     c = 2
 
-    f_vals = np.ndarray([N+1, npts[0], npts[1]])
+    f_vals = np.ndarray([N + 1, npts[0], npts[1]])
 
     domain = [[0, 2*pi], [0, 20]]
-    nkts = [n+1 for n in npts]
+    nkts = [n + 1 for n in npts]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, 3, True) for b in breaks]
     bsplines = [spl.BSplines(k, 3, True) for k in knots]
@@ -47,8 +50,8 @@ def test_fluxSurfaceAdvection():
     f_vals[0, :, :] = np.sin(eta_vals[2]*pi/10)
 
     for n in range(N):
-        f_vals[n+1, :, :] = f_vals[n, :, :]
-        fluxAdv.step(f_vals[n+1, :, :], 0)
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        fluxAdv.step(f_vals[n + 1, :, :], 0)
 
     x, y = np.meshgrid(eta_vals[2], eta_vals[1])
 
@@ -78,6 +81,9 @@ def test_fluxSurfaceAdvection():
 
 @pytest.mark.serial
 def test_poloidalAdvection_invariantPhi():
+    """
+    TODO
+    """
     npts = [30, 20]
     eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
                 np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
@@ -85,15 +91,15 @@ def test_poloidalAdvection_invariantPhi():
     N = 200
     dt = 0.1
 
-    v = 0
+    v = 0.0
 
-    f_vals = np.ndarray([N+1, npts[1], npts[0]])
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
 
     deg = 3
 
     domain = [[0.1, 14.5], [0, 2*pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -108,8 +114,8 @@ def test_poloidalAdvection_invariantPhi():
 
     phi = spl.Spline2D(bsplines[1], bsplines[0])
     phiVals = np.empty([npts[1], npts[0]])
-    phiVals[:] = 3*eta_vals[0]**2 * \
-        (1 + 1e-1 * np.cos(np.atleast_2d(eta_vals[1]).T*2))
+    phiVals[:] = 3 * eta_vals[0]**2 * \
+        (1 + 1e-1 * np.cos(np.atleast_2d(eta_vals[1]).T * 2))
     # phiVals[:]=10*eta_vals[0]
     interp = spl.SplineInterpolator2D(bsplines[1], bsplines[0])
 
@@ -126,8 +132,93 @@ def test_poloidalAdvection_invariantPhi():
                                      constants.deltaRTi)
 
     for n in range(N):
-        f_vals[n+1, :, :] = f_vals[n, :, :]
-        polAdv.step(f_vals[n+1, :, :], dt, phi, v)
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, phi, v)
+
+    f_min = np.min(f_vals)
+    f_max = np.max(f_vals)
+
+    plt.ion()
+
+    fig = plt.figure()
+    ax = plt.subplot(111, projection='polar')
+    #ax = fig.add_axes([0.1, 0.25, 0.7, 0.7],)
+    colorbarax2 = fig.add_axes([0.85, 0.1, 0.03, 0.8],)
+
+    plotParams = {'vmin': f_min, 'vmax': f_max, 'cmap': "jet"}
+
+    line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                        f_vals[0, :, :].T, 20, **plotParams)
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+    fig.colorbar(line1, cax=colorbarax2)
+
+    for n in range(1, N):
+        for coll in line1.collections:
+            coll.remove()
+        del line1
+        line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                            f_vals[n, :, :].T, 20, **plotParams)
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+
+
+@pytest.mark.serial
+def test_poloidalAdvectionArakawa_invariantPhi():
+    """
+    TODO
+    """
+    npts = [30, 20]
+    eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
+                np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
+
+    N = 200
+    dt = 0.1
+
+    v = 0.0
+
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
+
+    deg = 3
+
+    domain = [[0.1, 14.5], [0, 2*pi]]
+    periodic = [False, True]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
+    breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
+    knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
+    bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
+    eta_grids = [bspl.greville for bspl in bsplines]
+
+    eta_vals[0] = eta_grids[0]
+    eta_vals[1] = eta_grids[1]
+
+    constants = get_constants('testSetups/iota0.json')
+
+    polAdv = PoloidalAdvectionArakawa(eta_vals, constants)
+
+    phi = spl.Spline2D(bsplines[1], bsplines[0])
+    phiVals = np.empty([npts[1], npts[0]])
+    phiVals[:] = 3 * eta_vals[0]**2 * \
+        (1 + 1e-1 * np.cos(np.atleast_2d(eta_vals[1]).T * 2))
+    # phiVals[:]=10*eta_vals[0]
+    interp = spl.SplineInterpolator2D(bsplines[1], bsplines[0])
+
+    interp.compute_interpolant(phiVals, phi)
+
+    # ~ f_vals[0,:,:] = np.exp(-np.atleast_2d((eta_vals[1]-pi)**2).T - (eta_vals[0]-7)**2)/4 \
+    # ~ + fEq(0.1,v,constants.CN0,constants.kN0,
+    #~ constants.deltaRN0,constants.rp,
+    #~ constants.CTi,constants.kTi,
+    # ~ constants.deltaRTi)
+    f_vals[0, :, :] = phiVals + f_eq(0.1, v, constants.CN0, constants.kN0,
+                                     constants.deltaRN0, constants.rp,
+                                     constants.CTi, constants.kTi,
+                                     constants.deltaRTi)
+
+    for n in range(N):
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, np.array(phiVals, dtype=float))
 
     f_min = np.min(f_vals)
     f_max = np.max(f_vals)
@@ -160,6 +251,9 @@ def test_poloidalAdvection_invariantPhi():
 
 @pytest.mark.serial
 def test_poloidalAdvection_vortex():
+    """
+    TODO
+    """
     npts = [30, 20]
     eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
                 np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
@@ -167,15 +261,15 @@ def test_poloidalAdvection_vortex():
     N = 200
     dt = 0.1
 
-    v = 0
+    v = 0.0
 
-    f_vals = np.ndarray([N+1, npts[1], npts[0]])
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
 
     deg = 3
 
     domain = [[0.1, 14.5], [0, 2*pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -195,15 +289,93 @@ def test_poloidalAdvection_vortex():
 
     interp.compute_interpolant(phiVals, phi)
 
-    f_vals[0, :, :] = np.exp(-np.atleast_2d((eta_vals[1]-pi)**2).T - (eta_vals[0]-7)**2)/4 \
+    f_vals[0, :, :] = np.exp(-np.atleast_2d((eta_vals[1] - pi)**2).T - (eta_vals[0] - 7)**2) / 4 \
         + f_eq(0.1, v, constants.CN0, constants.kN0,
                constants.deltaRN0, constants.rp,
                constants.CTi, constants.kTi,
                constants.deltaRTi)
 
     for n in range(N):
-        f_vals[n+1, :, :] = f_vals[n, :, :]
-        polAdv.step(f_vals[n+1, :, :], dt, phi, v)
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, phi, v)
+
+    f_min = np.min(f_vals)
+    f_max = np.max(f_vals)
+
+    plt.ion()
+
+    fig = plt.figure()
+    ax = plt.subplot(111, projection='polar')
+    #ax = fig.add_axes([0.1, 0.25, 0.7, 0.7],)
+    colorbarax2 = fig.add_axes([0.85, 0.1, 0.03, 0.8],)
+
+    plotParams = {'vmin': f_min, 'vmax': f_max, 'cmap': "jet"}
+
+    line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                        f_vals[0, :, :].T, 20, **plotParams)
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+    fig.colorbar(line1, cax=colorbarax2)
+
+    for n in range(1, N):
+        for coll in line1.collections:
+            coll.remove()
+        del line1
+        line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                            f_vals[n, :, :].T, 20, **plotParams)
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+
+@pytest.mark.serial
+def test_poloidalAdvectionArakawa_vortex():
+    """
+    TODO
+    """
+    npts = [30, 20]
+    eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
+                np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
+
+    N = 200
+    dt = 0.1
+
+    v = 0.0
+
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
+
+    deg = 3
+
+    domain = [[0.1, 14.5], [0, 2*pi]]
+    periodic = [False, True]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
+    breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
+    knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
+    bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
+    eta_grids = [bspl.greville for bspl in bsplines]
+
+    eta_vals[0] = eta_grids[0]
+    eta_vals[1] = eta_grids[1]
+
+    constants = get_constants('testSetups/iota0.json')
+
+    polAdv = PoloidalAdvectionArakawa(eta_vals, bsplines[::-1], constants)
+
+    phi = spl.Spline2D(bsplines[1], bsplines[0])
+    phiVals = np.empty([npts[1], npts[0]])
+    phiVals[:] = 10 * eta_vals[0]
+    interp = spl.SplineInterpolator2D(bsplines[1], bsplines[0])
+
+    interp.compute_interpolant(phiVals, phi)
+
+    f_vals[0, :, :] = np.exp(-np.atleast_2d((eta_vals[1] - pi)**2).T - (eta_vals[0] - 7)**2) / 4 \
+        + f_eq(0.1, v, constants.CN0, constants.kN0,
+               constants.deltaRN0, constants.rp,
+               constants.CTi, constants.kTi,
+               constants.deltaRTi)
+
+    for n in range(N):
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, np.array(phiVals, dtype=float))
 
     f_min = np.min(f_vals)
     f_max = np.max(f_vals)
@@ -236,6 +408,9 @@ def test_poloidalAdvection_vortex():
 
 @pytest.mark.serial
 def test_poloidalAdvection_constantAdv():
+    """
+    TODO
+    """
     npts = [30, 20]
     eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
                 np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
@@ -243,15 +418,15 @@ def test_poloidalAdvection_constantAdv():
     N = 200
     dt = 0.1
 
-    v = 0
+    v = 0.0
 
-    f_vals = np.ndarray([N+1, npts[1], npts[0]])
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
 
     deg = 3
 
     domain = [[0.1, 14.5], [0, 2*pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -278,8 +453,87 @@ def test_poloidalAdvection_constantAdv():
                constants.deltaRTi)
 
     for n in range(N):
-        f_vals[n+1, :, :] = f_vals[n, :, :]
-        polAdv.step(f_vals[n+1, :, :], dt, phi, v)
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, phi, v)
+
+    f_min = np.min(f_vals)
+    f_max = np.max(f_vals)
+
+    plt.ion()
+
+    fig = plt.figure()
+    ax = plt.subplot(111, projection='polar')
+    #ax = fig.add_axes([0.1, 0.25, 0.7, 0.7],)
+    colorbarax2 = fig.add_axes([0.85, 0.1, 0.03, 0.8],)
+
+    plotParams = {'vmin': f_min, 'vmax': f_max, 'cmap': "jet"}
+
+    line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                        f_vals[0, :, :].T, 20, **plotParams)
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+    fig.colorbar(line1, cax=colorbarax2)
+
+    for n in range(1, N):
+        for coll in line1.collections:
+            coll.remove()
+        del line1
+        line1 = ax.contourf(eta_vals[1], eta_vals[0],
+                            f_vals[n, :, :].T, 20, **plotParams)
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+
+
+@pytest.mark.serial
+def test_poloidalAdvectionArakawa_constantAdv():
+    """
+    TODO
+    """
+    npts = [30, 20]
+    eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
+                np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
+
+    N = 200
+    dt = 0.1
+
+    v = 0.0
+
+    f_vals = np.ndarray([N + 1, npts[1], npts[0]])
+
+    deg = 3
+
+    domain = [[0.1, 14.5], [0, 2*pi]]
+    periodic = [False, True]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
+    breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
+    knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
+    bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
+    eta_grids = [bspl.greville for bspl in bsplines]
+
+    eta_vals[0] = eta_grids[0]
+    eta_vals[1] = eta_grids[1]
+
+    constants = get_constants('testSetups/iota0.json')
+
+    polAdv = PoloidalAdvectionArakawa(eta_vals, bsplines[::-1], constants)
+
+    phi = spl.Spline2D(bsplines[1], bsplines[0])
+    phiVals = np.empty([npts[1], npts[0]])
+    phiVals[:] = 3*eta_vals[0]**2
+    interp = spl.SplineInterpolator2D(bsplines[1], bsplines[0])
+
+    interp.compute_interpolant(phiVals, phi)
+
+    f_vals[0, :, :] = np.exp(-np.atleast_2d((eta_vals[1] - pi)**2).T - (eta_vals[0]-7)**2) / 4 \
+        + f_eq(0.1, v, constants.CN0, constants.kN0,
+               constants.deltaRN0, constants.rp,
+               constants.CTi, constants.kTi,
+               constants.deltaRTi)
+
+    for n in range(N):
+        f_vals[n + 1, :, :] = f_vals[n, :, :]
+        polAdv.step(f_vals[n + 1, :, :], dt, np.array(phiVals, dtype=float))
 
     f_min = np.min(f_vals)
     f_max = np.max(f_vals)
@@ -312,6 +566,9 @@ def test_poloidalAdvection_constantAdv():
 
 @pytest.mark.serial
 def test_vParallelAdvection():
+    """
+    TODO
+    """
     npts = [4, 4, 4, 100]
     grid, constants = setupCylindricalGrid(constantFile='testSetups/iota0.json',
                                            npts=npts,
@@ -347,6 +604,9 @@ def test_vParallelAdvection():
 
 
 def positional_Phi(r, theta, a, b, c, d):
+    """
+    TODO
+    """
     return - a * (r-b)**2 + c*np.sin(d*theta)
 
 
@@ -368,6 +628,9 @@ def initConditions(r,theta):
 
 
 def initConditions(r, theta):
+    """
+    TODO
+    """
     a = 4
     factor = pi/a/2
     r = np.sqrt((r-7)**2+2*(theta-pi)**2)
@@ -378,11 +641,14 @@ def initConditions(r, theta):
         return 0.0
 
 
-initConds = np.vectorize(initConditions, otypes=[np.float])
+initConds = np.vectorize(initConditions, otypes=[float])
 
 
 @pytest.mark.serial
 def test_poloidalAdvection():
+    """
+    TODO
+    """
     # ~ npts = [128,128]
     npts = [16, 16]
 
@@ -393,16 +659,16 @@ def test_poloidalAdvection():
     N = 100
     dt = 0.01
 
-    v = 0
+    v = 0.0
 
-    f_vals = np.ndarray([N+1, npts[1]+1, npts[0]])
-    # ~ f_vals = np.ndarray([N+1,npts[1],npts[0]])
+    f_vals = np.ndarray([N + 1, npts[1]+1, npts[0]])
+    # ~ f_vals = np.ndarray([N + 1,npts[1],npts[0]])
 
     deg = 3
 
     domain = [[1, 13], [0, 2*pi]]
     periodic = [False, True]
-    nkts = [n+1+deg*(int(p)-1) for (n, p) in zip(npts, periodic)]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
     bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
@@ -432,17 +698,19 @@ def test_poloidalAdvection():
     #f_vals[0,:,:] = initConds(eta_vals[0],np.atleast_2d(eta_vals[1]).T)
 
     endPts = (np.ndarray([npts[1], npts[0]]), np.ndarray([npts[1], npts[0]]))
-    endPts[0][:] = polAdv._shapedQ + 2*a*dt/constants.B0
-    endPts[1][:] = np.sqrt(polAdv._points[1]**2-c*np.sin(d*polAdv._shapedQ)/a/constants.B0
-                           + c*np.sin(d*endPts[0])/a/constants.B0)
+    endPts[0][:] = polAdv._shapedQ + 2 * a * dt / constants.B0
+    endPts[1][:] = np.sqrt(polAdv._points[1]**2 - c * np.sin(d * polAdv._shapedQ) / a / constants.B0
+                           + c * np.sin(d * endPts[0]) / a / constants.B0)
+
+    polAdv.allow_tests()
 
     for n in range(N):
-        f_vals[n+1, :-1, :] = f_vals[n, :-1, :]
-        # f_vals[:,:,n+1]=f_vals[:,:,n]
-        polAdv.exact_step(f_vals[n+1, :-1, :], endPts, v)
-        polAdv.step(f_vals[n+1, :-1, :], dt, phi, v)
-        # polAdv.step(f_vals[:,:,n+1],dt,phi,v)
-        # polAdv.exact_step(f_vals[:,:,n+1],endPts,v)
+        f_vals[n + 1, :-1, :] = f_vals[n, :-1, :]
+        # f_vals[:,:,n + 1]=f_vals[:,:,n]
+        polAdv.exact_step(f_vals[n + 1, :-1, :], endPts, v)
+        polAdv.step(f_vals[n + 1, :-1, :], dt, phi, v)
+        # polAdv.step(f_vals[:,:,n + 1],dt,phi,v)
+        # polAdv.exact_step(f_vals[:,:,n + 1],endPts,v)
 
     f_vals[:, -1, :] = f_vals[:, 0, :]
     f_min = np.min(f_vals)
@@ -475,7 +743,117 @@ def test_poloidalAdvection():
 
     fig.colorbar(line1, cax=colorbarax2)
 
-    for n in range(1, N+1):
+    for n in range(1, N + 1):
+        for coll in line1.collections:
+            coll.remove()
+        del line1
+        line1 = ax.contourf(
+            theta, eta_vals[0], f_vals[n, :, :].T, 20, **plotParams)
+        print(f_vals[n, :, :])
+        fig.canvas.draw()
+        fig.canvas.flush_events()
+
+
+@pytest.mark.serial
+def test_poloidalAdvectionArakawa():
+    """
+    TODO
+    """
+    # ~ npts = [128,128]
+    npts = [16, 16]
+
+    print(npts)
+    eta_vals = [np.linspace(0, 20, npts[1], endpoint=False), np.linspace(0, 2*pi, npts[0], endpoint=False),
+                np.linspace(0, 1, 4), np.linspace(0, 1, 4)]
+
+    N = 100
+    dt = 0.01
+
+    v = 0.0
+
+    f_vals = np.ndarray([N + 1, npts[1] + 1, npts[0]])
+    # ~ f_vals = np.ndarray([N + 1,npts[1],npts[0]])
+
+    deg = 3
+
+    domain = [[1, 13], [0, 2*pi]]
+    periodic = [False, True]
+    nkts = [n + 1 + deg * (int(p) - 1) for (n, p) in zip(npts, periodic)]
+    breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
+    knots = [spl.make_knots(b, deg, p) for b, p in zip(breaks, periodic)]
+    bsplines = [spl.BSplines(k, deg, p) for k, p in zip(knots, periodic)]
+    eta_grids = [bspl.greville for bspl in bsplines]
+
+    eta_vals[0] = eta_grids[0]
+    eta_vals[1] = eta_grids[1]
+
+    constants = get_constants('testSetups/iota0.json')
+
+    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, True)
+
+    phi = spl.Spline2D(bsplines[1], bsplines[0])
+    phiVals = np.empty([npts[1], npts[0]])
+    a = 5
+    b = 0
+    c = 40
+    d = 1
+    phiVals[:] = positional_Phi(
+        eta_vals[0], np.atleast_2d(eta_vals[1]).T, a, b, c, d)
+    interp = spl.SplineInterpolator2D(bsplines[1], bsplines[0])
+
+    interp.compute_interpolant(phiVals, phi)
+
+    f_vals[0, :-1, :] = initConds(eta_vals[0], np.atleast_2d(eta_vals[1]).T)
+    f_vals[0, -1, :] = f_vals[0, 0, :]
+    #f_vals[0,:,:] = initConds(eta_vals[0],np.atleast_2d(eta_vals[1]).T)
+
+    endPts = (np.ndarray([npts[1], npts[0]]), np.ndarray([npts[1], npts[0]]))
+    endPts[0][:] = polAdv._shapedQ + 2 * a * dt / constants.B0
+    endPts[1][:] = np.sqrt(polAdv._points[1]**2 - c * np.sin(d * polAdv._shapedQ) / a / constants.B0
+                           + c * np.sin(d * endPts[0]) / a / constants.B0)
+
+    polAdv.allow_tests()
+
+    for n in range(N):
+        f_vals[n + 1, :-1, :] = f_vals[n, :-1, :]
+        # f_vals[:,:,n + 1]=f_vals[:,:,n]
+        polAdv.exact_step(f_vals[n + 1, :-1, :], endPts, v)
+        polAdv.step(f_vals[n + 1, :-1, :], dt, np.array(phiVals, dtype=float))
+        # polAdv.step(f_vals[:,:,n + 1],dt,phi,v)
+        # polAdv.exact_step(f_vals[:,:,n + 1],endPts,v)
+
+    f_vals[:, -1, :] = f_vals[:, 0, :]
+    f_min = np.min(f_vals)
+    f_max = np.max(f_vals)
+
+    print(f_min, f_max)
+
+    theta = np.append(eta_vals[1], eta_vals[1][0])
+    # theta=eta_vals[1]
+
+    plt.ion()
+
+    font = {'size': 16}
+
+    pltFont('font', **font)
+
+    fig = plt.figure()
+    ax = plt.subplot(111, projection='polar')
+    ax.set_rlim(0, 13)
+    colorbarax2 = fig.add_axes([0.85, 0.1, 0.03, 0.8],)
+
+    norm = colors.BoundaryNorm(
+        boundaries=np.linspace(-1, 1, 41), ncolors=256, clip=True)
+    plotParams = {'vmin': -1, 'vmax': 1, 'norm': norm, 'cmap': "jet"}
+
+    line1 = ax.contourf(theta, eta_vals[0],
+                        f_vals[0, :, :].T, 20, **plotParams)
+    fig.canvas.draw()
+    fig.canvas.flush_events()
+
+    fig.colorbar(line1, cax=colorbarax2)
+
+    for n in range(1, N + 1):
         for coll in line1.collections:
             coll.remove()
         del line1
@@ -487,28 +865,40 @@ def test_poloidalAdvection():
 
 
 def initConditionsFlux(theta, z):
+    """
+    TODO
+    """
     a = 4
     factor = pi/a/2
-    r = np.sqrt((z-10)**2+2*(theta-4)**2)
+    r = np.sqrt((z - 10)**2 + 2 * (theta - 4)**2)
     if (r <= 4):
-        return np.cos(r*factor)**6
+        return np.cos(r * factor)**6
     else:
         return 0.0
 
 
-initCondsF = np.vectorize(initConditionsFlux, otypes=[np.float])
+initCondsF = np.vectorize(initConditionsFlux, otypes=[float])
 
 
 def iota0(r=6.0):
+    """
+    TODO
+    """
     return np.full_like(r, 0.0, dtype=float)
 
 
 def iota8(r=6.0):
+    """
+    TODO
+    """
     return np.full_like(r, 0.8, dtype=float)
 
 
 @pytest.mark.serial
 def test_fluxAdvection_dz():
+    """
+    TODO
+    """
     dt = 0.1
     npts = [64, 64]
 
@@ -523,10 +913,10 @@ def test_fluxAdvection_dz():
 
     c = 2
 
-    f_vals = np.ndarray([N+1, npts[0], npts[1]])
+    f_vals = np.ndarray([N + 1, npts[0], npts[1]])
 
     domain = [[0, 2*pi], [0, 20]]
-    nkts = [n+1 for n in npts]
+    nkts = [n + 1 for n in npts]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, 3, True) for b in breaks]
     bsplines = [spl.BSplines(k, 3, True) for k in knots]
@@ -546,7 +936,7 @@ def test_fluxAdvection_dz():
 
     f_vals[0, :, :] = initCondsF(np.atleast_2d(eta_vals[1]).T, eta_vals[2])
 
-    for n in range(1, N+1):
+    for n in range(1, N + 1):
         f_vals[n, :, :] = f_vals[n-1, :, :]
         fluxAdv.step(f_vals[n, :, :], 0)
 
@@ -572,7 +962,7 @@ def test_fluxAdvection_dz():
 
     #~ plt.show()
 
-    for n in range(1, N+1):
+    for n in range(1, N + 1):
         del line1
         line1 = ax.pcolormesh(x, y, f_vals[n, :, :], vmin=f_min, vmax=f_max)
         # ~ line1 = ax.pcolormesh(y,x,f_vals[n,:,:],vmin=f_min,vmax=f_max)
@@ -581,6 +971,9 @@ def test_fluxAdvection_dz():
 
 
 def test_flux_aligned():
+    """
+    TODO
+    """
     dt = 0.1
     npts = [64, 64]
 
@@ -591,14 +984,14 @@ def test_flux_aligned():
     N = 100
 
     eta_vals = [np.linspace(0, 1, 4), np.linspace(0, 2*pi, npts[0], endpoint=False),
-                np.linspace(0, 2*pi*constants.R0, npts[1], endpoint=False), np.linspace(0, 1, 4)]
+                np.linspace(0, 2*pi * constants.R0, npts[1], endpoint=False), np.linspace(0, 1, 4)]
 
     c = 2
 
-    f_vals = np.ndarray([N+1, npts[0], npts[1]])
+    f_vals = np.ndarray([N + 1, npts[0], npts[1]])
 
-    domain = [[0, 2*pi], [0, 2*pi*constants.R0]]
-    nkts = [n+1 for n in npts]
+    domain = [[0, 2*pi], [0, 2*pi * constants.R0]]
+    nkts = [n + 1 for n in npts]
     breaks = [np.linspace(*lims, num=num) for (lims, num) in zip(domain, nkts)]
     knots = [spl.make_knots(b, 3, True) for b in breaks]
     bsplines = [spl.BSplines(k, 3, True) for k in knots]
@@ -613,8 +1006,8 @@ def test_flux_aligned():
 
     m, n = (5, 4)
     theta = eta_grids[0]
-    phi = eta_grids[1]*2*pi/domain[1][1]
-    f_vals[0, :, :] = 0.5 + 0.5 * np.sin(m*theta[:, None] - n*phi[None, :])
+    phi = eta_grids[1] * 2*pi / domain[1][1]
+    f_vals[0, :, :] = 0.5 + 0.5 * np.sin(m * theta[:, None] - n * phi[None, :])
 
     # ~ m, n = (4, 5)
     # ~ m, n = (0, 5)
@@ -622,7 +1015,7 @@ def test_flux_aligned():
     # ~ phi = eta_grids[1]*2*pi/domain[1][1]
     # ~ f_vals[:,:,0] = 0.5+ 0.5*np.sin( m*theta[:,None] + n*phi[None,:] )
 
-    for n in range(1, N+1):
+    for n in range(1, N + 1):
         f_vals[n, :, :] = f_vals[n-1, :, :]
         fluxAdv.step(f_vals[n, :, :], 0)
 
@@ -664,7 +1057,7 @@ def test_flux_aligned():
 
     #~ plt.show()
 
-    for n in range(1, N+1):
+    for n in range(1, N + 1):
         del line1
         del line2
         # ~ line1 = ax.pcolormesh(phi,theta,f_vals[:,:,n],vmin=f_min,vmax=f_max)
@@ -681,23 +1074,32 @@ def test_flux_aligned():
 
 
 def Phi(theta, z):
+    """
+    TODO
+    """
     # return np.cos(z*pi*0.1) + np.sin(theta)
     # ~ return np.sin(z*pi*0.1)**2 + np.cos(theta)**2
     m, n = (5, 4)
-    phi = z*2*np.pi/20
-    return 0.5 + 0.5*np.sin(m*theta - n*phi)
+    phi = z * 2*np.pi / 20
+    return 0.5 + 0.5 * np.sin(m * theta - n * phi)
 
 
 def dPhi(r, theta, z, btheta, bz):
+    """
+    TODO
+    """
     # return -np.sin(z*pi*0.1)*pi*0.1*bz + np.cos(theta)*btheta
     # ~ return 2*np.sin(z*pi*0.1)*np.cos(z*pi*0.1)*pi*0.1*bz - 2*np.cos(theta)*np.sin(theta)*btheta/r
     m, n = (5, 4)
-    phi = z*2*np.pi/20
-    return 0.5*np.cos(m*theta - n*phi)*(m*btheta/r - bz*n*2*np.pi/20)
+    phi = z * 2*np.pi / 20
+    return 0.5 * np.cos(m * theta - n * phi) * (m * btheta / r - bz * n * 2*np.pi / 20)
 
 
 @pytest.mark.serial
 def test_Phi_deriv():
+    """
+    TODO
+    """
     npts = [1, 64, 128]
 
     constants = get_constants('testSetups/iota8.json')

--- a/pygyro/arakawa/discrete_brackets_polar.py
+++ b/pygyro/arakawa/discrete_brackets_polar.py
@@ -14,14 +14,15 @@ def neighbor_index(pos0, pos1, i0, i1, nPoints_theta, nPoints_r):
     -------
         TODO
     """
-    index = (i0 + pos0) % nPoints_theta + ((i1 + pos1) % nPoints_r) * nPoints_theta
+    index = (i0 + pos0) % nPoints_theta + \
+        ((i1 + pos1) % nPoints_r) * nPoints_theta
     return index
 
 
 def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     TODO
-    
+
     Parameters
     ----------
         scheme : str
@@ -29,9 +30,9 @@ def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
 
         bc : str
             determines the boundary condition for r
-        
+
         TODO
-    
+
     Returns
     -------
         TODO
@@ -49,26 +50,37 @@ def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
         elif scheme == 'xp':
             J_phi = -assemble_Jxp(phi_hh, nPoints_theta, nPoints_r, r_grid)
         else:
-            raise NotImplementedError(f'Unknown option for the scheme : {scheme}')
+            raise NotImplementedError(
+                f'Unknown option for the scheme : {scheme}')
 
     elif bc == 'dirichlet':
         if scheme == 'akw':
-            Jpp = assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
-            Jpx = -assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
-            Jxp = -assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jpp = assemble_Jpp_dirichlet(
+                phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jpx = -assemble_Jpx_dirichlet(phi_hh,
+                                          nPoints_theta, nPoints_r, r_grid)
+            Jxp = -assemble_Jxp_dirichlet(phi_hh,
+                                          nPoints_theta, nPoints_r, r_grid)
             J_phi = 1/3 * (Jpp + Jpx + Jxp)
         elif scheme == 'pp':
-            J_phi = assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            J_phi = assemble_Jpp_dirichlet(
+                phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'px':
-            J_phi = -assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            J_phi = - \
+                assemble_Jpx_dirichlet(
+                    phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'xp':
-            J_phi = -assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            J_phi = - \
+                assemble_Jxp_dirichlet(
+                    phi_hh, nPoints_theta, nPoints_r, r_grid)
         else:
-            raise NotImplementedError(f'Unknown option for the scheme : {scheme}')
-    
+            raise NotImplementedError(
+                f'Unknown option for the scheme : {scheme}')
+
     else:
-        raise NotImplementedError(f'Unknown option for boundary conditions : {bc}')
-    
+        raise NotImplementedError(
+            f'Unknown option for boundary conditions : {bc}')
+
     return J_phi
 
 
@@ -112,7 +124,8 @@ def assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid):
         data.append(-coef)
 
         # .. terms -(phi_+0 - phi_-0)/4h^2 * (f_0+ - f_0-)
-        coef = - phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
+        coef = - \
+            phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef += phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
@@ -173,7 +186,8 @@ def assemble_Jpx(phi_hh, nPoints_theta, nPoints_r, r_grid):
         data.append(-coef)
 
         # .. terms -phi_--/4h^2 * (f_-0 - f_0-)
-        coef = - phi_hh[neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r)]
+        coef = - \
+            phi_hh[neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
@@ -185,7 +199,8 @@ def assemble_Jpx(phi_hh, nPoints_theta, nPoints_r, r_grid):
         data.append(-coef)
 
         # .. terms -phi_-+/4h^2 * (f_0+ - f_-0)
-        coef = - phi_hh[neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r)]
+        coef = - \
+            phi_hh[neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
@@ -257,7 +272,8 @@ def assemble_Jxp(phi_hh, nPoints_theta, nPoints_r, r_grid):
         data.append(-coef)
 
         # .. terms -phi_-0/4h^2 * (f_-+ - f_--)
-        coef = - phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
+        coef = - \
+            phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
@@ -330,8 +346,10 @@ def assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
 
         if i1 != 0 and i1 != nPoints_r-1:
             # .. terms (phi_0+ - phi_0-)/4h^2 * (f_+0 - f_-0)
-            coef = phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
-            coef -= phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
+            coef = phi_hh[neighbor_index(
+                0, +1, i0, i1, nPoints_theta, nPoints_r)]
+            coef -= phi_hh[neighbor_index(0, -1,
+                                          i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -343,8 +361,10 @@ def assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
             data.append(-coef)
 
             # .. terms -(phi_+0 - phi_-0)/4h^2 * (f_0+ - f_0-)
-            coef = -phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
-            coef += phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
+            coef = - \
+                phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
+            coef += phi_hh[neighbor_index(-1, 0,
+                                          i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -393,7 +413,8 @@ def assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
 
         if i1 != 0 and i1 != nPoints_r-1:
             # .. terms phi_++/4h^2 * (f_0+ - f_+0)
-            coef = phi_hh[neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r)]
+            coef = phi_hh[neighbor_index(+1, +1,
+                                         i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -406,7 +427,8 @@ def assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
 
             # .. terms -phi_--/4h^2 * (f_-0 - f_0-)
             coef = - \
-                phi_hh[neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r)]
+                phi_hh[neighbor_index(-1, -1, i0, i1,
+                                      nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -419,7 +441,8 @@ def assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
 
             # .. terms -phi_-+/4h^2 * (f_0+ - f_-0)
             coef = - \
-                phi_hh[neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r)]
+                phi_hh[neighbor_index(-1, +1, i0, i1,
+                                      nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -431,7 +454,8 @@ def assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
             data.append(-coef)
 
             # .. terms phi_+-/4h^2 * (f_+0 - f_0-)
-            coef = phi_hh[neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r)]
+            coef = phi_hh[neighbor_index(+1, -1,
+                                         i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
@@ -476,51 +500,63 @@ def assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
 
         if i1 != 0 and i1 != nPoints_r-1:
             # .. terms phi_+0/4h^2 * (f_++ - f_+-)
-            coef = phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
+            coef = phi_hh[neighbor_index(+1, 0, i0,
+                                         i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(+1, +1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(+1, -1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_-0/4h^2 * (f_-+ - f_--)
-            coef = -phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
+            coef = - \
+                phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(-1, +1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(-1, -1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_0+/4h^2 * (f_++ - f_-+)
-            coef = -phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
+            coef = - \
+                phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(+1, +1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(-1, +1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms phi_0-/4h^2 * (f_+- - f_--)
-            coef = phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
+            coef = phi_hh[neighbor_index(
+                0, -1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(+1, -1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
+            col.append(neighbor_index(-1, -1, i0,
+                       i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
     row = np.array(row)

--- a/pygyro/arakawa/discrete_brackets_polar.py
+++ b/pygyro/arakawa/discrete_brackets_polar.py
@@ -37,6 +37,7 @@ def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
     -------
         TODO
     """
+    
     if bc == 'periodic':
         if scheme == 'akw':
             Jpp = assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid)

--- a/pygyro/arakawa/discrete_brackets_polar.py
+++ b/pygyro/arakawa/discrete_brackets_polar.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.sparse as sparse
 
 
-def neighbor_index(pos0, pos1, i0, i1, N0_nodes0, N0_nodes1):
+def neighbor_index(pos0, pos1, i0, i1, nPoints_theta, nPoints_r):
     """
     TODO
 
@@ -14,43 +14,65 @@ def neighbor_index(pos0, pos1, i0, i1, N0_nodes0, N0_nodes1):
     -------
         TODO
     """
-    index = (i0 + pos0) % N0_nodes0 + ((i1 + pos1) % N0_nodes1) * N0_nodes0
+    index = (i0 + pos0) % nPoints_theta + ((i1 + pos1) % nPoints_r) * nPoints_theta
     return index
 
 
-def assemble_bracket(scheme, bc, phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
+    """
+    TODO
+    
+    Parameters
+    ----------
+        scheme : str
+            which scheme for the stencil matrix is to be used ('pp', 'px', 'xp', 'akw')
+
+        bc : str
+            determines the boundary condition for r
+        
+        TODO
+    
+    Returns
+    -------
+        TODO
+    """
     if bc == 'periodic':
         if scheme == 'akw':
-            Jpp = assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            Jpx = -assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            Jxp = -assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            return 1/3 * (Jpp + Jpx + Jxp)
+            Jpp = assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jpx = -assemble_Jpx(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jxp = -assemble_Jxp(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            J_phi = 1/3 * (Jpp + Jpx + Jxp)
         elif scheme == 'pp':
-            return assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'px':
-            return -assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = -assemble_Jpx(phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'xp':
-            return -assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = -assemble_Jxp(phi_hh, nPoints_theta, nPoints_r, r_grid)
         else:
-            print("scheme not found")
+            raise NotImplementedError(f'Unknown option for the scheme : {scheme}')
 
     elif bc == 'dirichlet':
         if scheme == 'akw':
-            Jpp = assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            Jpx = -assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            Jxp = -assemble_Jxp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
-            return 1/3 * (Jpp + Jpx + Jxp)
+            Jpp = assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jpx = -assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            Jxp = -assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
+            J_phi = 1/3 * (Jpp + Jpx + Jxp)
         elif scheme == 'pp':
-            return assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'px':
-            return -assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = -assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
         elif scheme == 'xp':
-            return -assemble_Jxp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid)
+            J_phi = -assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid)
         else:
-            print("scheme not found")
+            raise NotImplementedError(f'Unknown option for the scheme : {scheme}')
+    
+    else:
+        raise NotImplementedError(f'Unknown option for boundary conditions : {bc}')
+    
+    return J_phi
 
 
-def assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_++(phi, . ) as sparse matrix 
 
@@ -65,7 +87,7 @@ def assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0 * N0_nodes1
+    N_nodes = nPoints_theta * nPoints_r
 
     row = list()
     col = list()
@@ -73,33 +95,33 @@ def assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii // N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii // nPoints_theta
 
         # .. terms (phi_0+ - phi_0-)/4h^2 * (f_+0 - f_-0)
-        coef = phi_hh[neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1)]
-        coef -= phi_hh[neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
+        coef -= phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms -(phi_+0 - phi_-0)/4h^2 * (f_0+ - f_0-)
-        coef = - phi_hh[neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1)]
-        coef += phi_hh[neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = - phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
+        coef += phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
     row = np.array(row)
@@ -112,7 +134,7 @@ def assemble_Jpp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
     return res
 
 
-def assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jpx(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_+x(phi, . ) as sparse matrix 
 
@@ -127,7 +149,7 @@ def assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0*N0_nodes1
+    N_nodes = nPoints_theta*nPoints_r
 
     row = list()
     col = list()
@@ -135,55 +157,55 @@ def assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii // N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii // nPoints_theta
 
         # .. terms phi_++/4h^2 * (f_0+ - f_+0)
-        coef = phi_hh[neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = phi_hh[neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms -phi_--/4h^2 * (f_-0 - f_0-)
-        coef = - phi_hh[neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = - phi_hh[neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms -phi_-+/4h^2 * (f_0+ - f_-0)
-        coef = - phi_hh[neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = - phi_hh[neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms phi_+-/4h^2 * (f_+0 - f_0-)
-        coef = phi_hh[neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = phi_hh[neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
     row = np.array(row)
@@ -196,7 +218,7 @@ def assemble_Jpx(phi_hh, N0_nodes0, N0_nodes1, r_grid):
     return res
 
 
-def assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jxp(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_x+(phi, . ) as sparse matrix 
 
@@ -211,7 +233,7 @@ def assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0*N0_nodes1
+    N_nodes = nPoints_theta*nPoints_r
 
     row = list()
     col = list()
@@ -219,55 +241,55 @@ def assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii // N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii // nPoints_theta
 
         # .. terms phi_+0/4h^2 * (f_++ - f_+-)
-        coef = phi_hh[neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms -phi_-0/4h^2 * (f_-+ - f_--)
-        coef = - phi_hh[neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = - phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms -phi_0+/4h^2 * (f_++ - f_-+)
-        coef = -phi_hh[neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = -phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
         # .. terms phi_0-/4h^2 * (f_+- - f_--)
-        coef = phi_hh[neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1)]
+        coef = phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
         coef *= 1/r_grid[i1]
 
         row.append(ii)
-        col.append(neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(coef)
 
         row.append(ii)
-        col.append(neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1))
+        col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
         data.append(-coef)
 
     row = np.array(row)
@@ -280,7 +302,7 @@ def assemble_Jxp(phi_hh, N0_nodes0, N0_nodes1, r_grid):
     return res
 
 
-def assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jpp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_++(phi, . ) as sparse matrix 
 
@@ -295,7 +317,7 @@ def assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0 * N0_nodes1
+    N_nodes = nPoints_theta * nPoints_r
 
     row = list()
     col = list()
@@ -303,34 +325,34 @@ def assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii // N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii // nPoints_theta
 
-        if i1 != 0 and i1 != N0_nodes1-1:
+        if i1 != 0 and i1 != nPoints_r-1:
             # .. terms (phi_0+ - phi_0-)/4h^2 * (f_+0 - f_-0)
-            coef = phi_hh[neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1)]
-            coef -= phi_hh[neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
+            coef -= phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -(phi_+0 - phi_-0)/4h^2 * (f_0+ - f_0-)
-            coef = -phi_hh[neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1)]
-            coef += phi_hh[neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = -phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
+            coef += phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
     row = np.array(row)
@@ -343,7 +365,7 @@ def assemble_Jpp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
     return res
 
 
-def assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jpx_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_+x(phi, . ) as sparse matrix 
 
@@ -358,7 +380,7 @@ def assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0*N0_nodes1
+    N_nodes = nPoints_theta*nPoints_r
 
     row = list()
     col = list()
@@ -366,58 +388,58 @@ def assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii//N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii//nPoints_theta
 
-        if i1 != 0 and i1 != N0_nodes1-1:
+        if i1 != 0 and i1 != nPoints_r-1:
             # .. terms phi_++/4h^2 * (f_0+ - f_+0)
-            coef = phi_hh[neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = phi_hh[neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_--/4h^2 * (f_-0 - f_0-)
             coef = - \
-                phi_hh[neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1)]
+                phi_hh[neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_-+/4h^2 * (f_0+ - f_-0)
             coef = - \
-                phi_hh[neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1)]
+                phi_hh[neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms phi_+-/4h^2 * (f_+0 - f_0-)
-            coef = phi_hh[neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = phi_hh[neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
     row = np.array(row)
@@ -426,7 +448,7 @@ def assemble_Jpx_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
     return (sparse.coo_matrix((data, (row, col)), shape=(N_nodes, N_nodes))).tocsr()
 
 
-def assemble_Jxp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
+def assemble_Jxp_dirichlet(phi_hh, nPoints_theta, nPoints_r, r_grid):
     """
     assemble J_x+(phi, . ) as sparse matrix 
 
@@ -441,7 +463,7 @@ def assemble_Jxp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
         TODO
     """
 
-    N_nodes = N0_nodes0*N0_nodes1
+    N_nodes = nPoints_theta*nPoints_r
 
     row = list()
     col = list()
@@ -449,56 +471,56 @@ def assemble_Jxp_dirichlet(phi_hh, N0_nodes0, N0_nodes1, r_grid):
 
     for ii in range(N_nodes):
 
-        i0 = ii % N0_nodes0
-        i1 = ii//N0_nodes0
+        i0 = ii % nPoints_theta
+        i1 = ii//nPoints_theta
 
-        if i1 != 0 and i1 != N0_nodes1-1:
+        if i1 != 0 and i1 != nPoints_r-1:
             # .. terms phi_+0/4h^2 * (f_++ - f_+-)
-            coef = phi_hh[neighbor_index(+1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = phi_hh[neighbor_index(+1, 0, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_-0/4h^2 * (f_-+ - f_--)
-            coef = -phi_hh[neighbor_index(-1, 0, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = -phi_hh[neighbor_index(-1, 0, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms -phi_0+/4h^2 * (f_++ - f_-+)
-            coef = -phi_hh[neighbor_index(0, +1, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = -phi_hh[neighbor_index(0, +1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, +1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, +1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
             # .. terms phi_0-/4h^2 * (f_+- - f_--)
-            coef = phi_hh[neighbor_index(0, -1, i0, i1, N0_nodes0, N0_nodes1)]
+            coef = phi_hh[neighbor_index(0, -1, i0, i1, nPoints_theta, nPoints_r)]
             coef *= 1/r_grid[i1]
 
             row.append(ii)
-            col.append(neighbor_index(+1, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(+1, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(coef)
 
             row.append(ii)
-            col.append(neighbor_index(-1, -1, i0, i1, N0_nodes0, N0_nodes1))
+            col.append(neighbor_index(-1, -1, i0, i1, nPoints_theta, nPoints_r))
             data.append(-coef)
 
     row = np.array(row)

--- a/pygyro/arakawa/discrete_brackets_polar.py
+++ b/pygyro/arakawa/discrete_brackets_polar.py
@@ -37,7 +37,7 @@ def assemble_bracket(scheme, bc, phi_hh, nPoints_theta, nPoints_r, r_grid):
     -------
         TODO
     """
-    
+
     if bc == 'periodic':
         if scheme == 'akw':
             Jpp = assemble_Jpp(phi_hh, nPoints_theta, nPoints_r, r_grid)

--- a/pygyro/model/grid.py
+++ b/pygyro/model/grid.py
@@ -138,8 +138,9 @@ class Grid(object):
     def get1DSlice(self, *slices: 'ints'):
         """ get the 1D slice at the provided list of coordinates
         """
-        assert(len(slices) == self._nDims - 1)
-        slices.append(slice(self._nGlobalCoords[self._layout.dims_order[-1]]))
+        assert(len(slices) == self._nDims-1)
+        slices = slices + \
+            (slice(self._nGlobalCoords[self._layout.dims_order[-1]]),)
         return self._f[tuple(slices)]
 
     def get1DSpline(self):


### PR DESCRIPTION
- Add both `pytest` and visual tests for `advection.advection.PoloidalAdvectionArkawa` (in `advection.test_advection` and `advection.visual_test_advection` respectively)
- Make small changes to fullSimulation.py and pygyro/arakawa/discrete_brackets_polar.py
- Remove spline objects from pygyro/advection.advection.PoloidalAdvectionArakawa
- @FrederikSchnack please add documentation where indicated

