### PR TITLE
Add diagnostics for Arakawa step

### DIFF
--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -969,7 +969,7 @@ class PoloidalAdvectionArakawa:
         raise NotImplementedError(
             "This functionality has not been implemented yet!")
 
-    def gridStep(self, grid: Grid, phi: Grid, dt: float):
+    def gridStep(self, f: Grid, phi: Grid, dt: float):
         """
         TODO
 
@@ -981,25 +981,25 @@ class PoloidalAdvectionArakawa:
         -------
             TODO
         """
-        gridLayout = grid.getLayout(grid.currentLayout)
-        phiLayout = phi.getLayout(grid.currentLayout)
+        gridLayout = f.getLayout(f.currentLayout)
+        phiLayout = phi.getLayout(f.currentLayout)
 
         assert (gridLayout.dims_order[1:] == phiLayout.dims_order)
         assert (gridLayout.dims_order == (3, 2, 1, 0))
 
         if self.bc == "extrapolation":
             # Do step
-            for i, v in grid.getCoords(0):  # v
-                for j, _ in grid.getCoords(1):  # z
+            for i, v in f.getCoords(0):  # v
+                for j, _ in f.getCoords(1):  # z
 
                     # if v is in the middle of the velocity distribution and it is
                     # the first slice in z-direction save it before and after the step
-                    if self._save_conservation and i == (grid.eta_grid[3].size // 2) and j == 0:
-                        int_f_before = compute_int_f(grid.get2DSlice(i, j), self._dtheta, self._dr,
+                    if self._save_conservation and i == (f.eta_grid[3].size // 2) and j == 0:
+                        int_f_before = compute_int_f(f.get2DSlice(i, j), self._dtheta, self._dr,
                                                      self._points_r, method='trapz')
-                        int_f_squared_before = compute_int_f_squared(grid.get2DSlice(i, j), self._dtheta, self._dr,
+                        int_f_squared_before = compute_int_f_squared(f.get2DSlice(i, j), self._dtheta, self._dr,
                                                                      self._points_r, method='trapz')
-                        energy_before = get_total_energy(grid.get2DSlice(i, j), phi.get2DSlice(j), self._dtheta, self._dr,
+                        energy_before = get_total_energy(f.get2DSlice(i, j), phi.get2DSlice(j), self._dtheta, self._dr,
                                                          self._points_r, method='trapz')
                         with open(self._conservation_savefile, 'a') as savefile:
                             savefile.write(
@@ -1014,16 +1014,16 @@ class PoloidalAdvectionArakawa:
                                          self._constants.rp, self._constants.CTi, self._constants.kTi,
                                          self._constants.deltaRTi) for k in range(self.order)]
 
-                    self.step_extrapolation(grid.get2DSlice(
+                    self.step_extrapolation(f.get2DSlice(
                         i, j), dt, phi.get2DSlice(j), values_f, values_phi)
 
                     # Save conservation properties after step as well
-                    if self._save_conservation and i == (grid.eta_grid[3].size // 2) and j == 0:
-                        int_f_after = compute_int_f(grid.get2DSlice(i, j), self._dtheta, self._dr,
+                    if self._save_conservation and i == (f.eta_grid[3].size // 2) and j == 0:
+                        int_f_after = compute_int_f(f.get2DSlice(i, j), self._dtheta, self._dr,
                                                     self._points_r, method='trapz')
-                        int_f_squared_after = compute_int_f_squared(grid.get2DSlice(i, j), self._dtheta, self._dr,
+                        int_f_squared_after = compute_int_f_squared(f.get2DSlice(i, j), self._dtheta, self._dr,
                                                                     self._points_r, method='trapz')
-                        energy_after = get_total_energy(grid.get2DSlice(i, j), phi.get2DSlice(j), self._dtheta, self._dr,
+                        energy_after = get_total_energy(f.get2DSlice(i, j), phi.get2DSlice(j), self._dtheta, self._dr,
                                                         self._points_r, method='trapz')
                         with open(self._conservation_savefile, 'a') as savefile:
                             savefile.write(
@@ -1037,9 +1037,9 @@ class PoloidalAdvectionArakawa:
                                 + format(energy_before - energy_after, '.15E') + "\n")
         else:
             # Do step
-            for i, _ in grid.getCoords(0):  # v
-                for j, _ in grid.getCoords(1):  # z
-                    self.step_normal(grid.get2DSlice(
+            for i, _ in f.getCoords(0):  # v
+                for j, _ in f.getCoords(1):  # z
+                    self.step_normal(f.get2DSlice(
                         i, j), dt, phi.get2DSlice(j))
 
     def gridStep_SplinesUnchanged(self, grid: Grid, dt: float):

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -638,7 +638,7 @@ class PoloidalAdvectionArakawa:
     def __init__(self, eta_vals: list, constants,
                  bc="extrapolation", order=4,
                  equilibrium_outside=True, verbose=False,
-                 explicit: bool = True,
+                 explicit: bool = False,
                  save_conservation: bool = False, foldername=''):
         self._points = eta_vals[1::-1]
         self._points_theta = self._points[0]

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -667,7 +667,7 @@ class PoloidalAdvectionArakawa:
                 foldername) != 0, "When wanting to save, a foldername has to be given!"
             self._conservation_savefile = "{0}/akw_consv.txt".format(foldername)
             with open(self._conservation_savefile, 'w') as savefile:
-                savefile.write("int_f before\t\tint_f_sqd before\tenergy before\t\t\tint_f after\t\t\tint_f_sqd after\t\tenergy after\t\t\tdiff int_f\t\t\tdiff int_f_sqd\t\tdiff energy\n")
+                savefile.write("int_f before\t\t\tint_f_sqd before\t\tenergy before\t\t\tint_f after\t\t\t\tint_f_sqd after\t\t\tenergy after\t\t\tdiff int_f\t\t\t\tdiff int_f_sqd\t\t\tdiff energy\n")
 
         self.bc = bc
 
@@ -1003,7 +1003,7 @@ class PoloidalAdvectionArakawa:
                                                          self._points_r, method='trapz')
                         with open(self._conservation_savefile, 'a') as savefile:
                             savefile.write(
-                                str(int_f_before) + "\t" + str(int_f_squared_before) + "\t" + str(energy_before) + "\t")
+                                format(int_f_before, '.15E') + "\t" + format(int_f_squared_before, '.15E') + "\t" + format(energy_before, '.15E') + "\t")
 
                     # assume phi equals 0 outside
                     values_phi = np.zeros(self.order)
@@ -1027,14 +1027,14 @@ class PoloidalAdvectionArakawa:
                                                         self._points_r, method='trapz')
                         with open(self._conservation_savefile, 'a') as savefile:
                             savefile.write(
-                                str(int_f_after) + "\t" + str(int_f_squared_after) + "\t" + str(energy_after) + "\t")
+                                format(int_f_after, '.15E') + "\t" + format(int_f_squared_after, '.15E') + "\t" + format(energy_after, '.15E') + "\t")
 
                         with open(self._conservation_savefile, 'a') as savefile:
                             savefile.write(
-                                str(int_f_before - int_f_after) + "\t"
-                                + str(int_f_squared_before -
-                                      int_f_squared_after) + "\t"
-                                + str(energy_before - energy_after) + "\n")
+                                format(int_f_before - int_f_after, '.15E') + "\t"
+                                + format(int_f_squared_before -
+                                      int_f_squared_after, '.15E') + "\t"
+                                + format(energy_before - energy_after, '.15E') + "\n")
         else:
             # Do step
             for i, _ in grid.getCoords(0):  # v

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -604,7 +604,7 @@ class PoloidalAdvectionArakawa:
     ----------
         eta_vals: list of array_like
             The coordinates of the grid points in each dimension. Index [0] must be
-            the radial coordinate, index [1] must be the angular coordinate. 
+            the radial coordinate, index [1] must be the angular coordinate.
 
         constants : Constant class
             Class containing all the constants

--- a/pygyro/advection/advection.py
+++ b/pygyro/advection/advection.py
@@ -986,7 +986,7 @@ class PoloidalAdvectionArakawa:
 
             phi : pygyro.model.grid.Grid
                 Grid object that characterizes the electric field
-            
+
             dt : float
                 Stepsize of the time stepping
         """
@@ -1050,10 +1050,10 @@ class PoloidalAdvectionArakawa:
 
             f : pygyro.model.grid.Grid
                 Grid object that characterizes the distribution function
-            
+
             idx_v : int
                 Index of the slice in v direction
-            
+
             idx_z : int
                 Index of the slice in z direction
 

--- a/pygyro/advection/test_advection.py
+++ b/pygyro/advection/test_advection.py
@@ -489,7 +489,7 @@ def test_poloidalAdvectionArakawaImplicit(dt, omega, xc, yc, order, bc, int_meth
 
     constants = Constants()
 
-    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, bc=bc, order=order)
+    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, bc=bc, order=order, explicit=False)
 
     d_theta = polAdv._dtheta
     d_r = polAdv._dr
@@ -607,7 +607,7 @@ def test_poloidalAdvectionArakawa_gridIntegration():
 
     basis = grid.get2DSpline()
 
-    polAdv = PoloidalAdvectionArakawa(grid.eta_grid, constants)
+    polAdv = PoloidalAdvectionArakawa(grid.eta_grid, constants, explicit=False)
 
     phi = spl.Spline2D(basis[0], basis[1])
     phiVals = np.full((npts[1], npts[0]), 2)

--- a/pygyro/advection/test_advection.py
+++ b/pygyro/advection/test_advection.py
@@ -489,7 +489,8 @@ def test_poloidalAdvectionArakawaImplicit(dt, omega, xc, yc, order, bc, int_meth
 
     constants = Constants()
 
-    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, bc=bc, order=order, explicit=False)
+    polAdv = PoloidalAdvectionArakawa(
+        eta_vals, constants, bc=bc, order=order, explicit=False)
 
     d_theta = polAdv._dtheta
     d_r = polAdv._dr

--- a/pygyro/advection/visual_test_advection.py
+++ b/pygyro/advection/visual_test_advection.py
@@ -197,7 +197,7 @@ def test_poloidalAdvectionArakawa_invariantPhi():
 
     constants = get_constants('testSetups/iota0.json')
 
-    polAdv = PoloidalAdvectionArakawa(eta_vals, constants)
+    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, explicit=False)
 
     phi = spl.Spline2D(bsplines[1], bsplines[0])
     phiVals = np.empty([npts[1], npts[0]])
@@ -363,7 +363,7 @@ def test_poloidalAdvectionArakawa_vortex():
 
     constants = get_constants('testSetups/iota0.json')
 
-    polAdv = PoloidalAdvectionArakawa(eta_vals, constants)
+    polAdv = PoloidalAdvectionArakawa(eta_vals, constants, explicit=False)
 
     phi = spl.Spline2D(bsplines[1], bsplines[0])
     phiVals = np.empty([npts[1], npts[0]])

--- a/pygyro/arakawa/utilities.py
+++ b/pygyro/arakawa/utilities.py
@@ -286,6 +286,9 @@ def get_total_energy(f: np.ndarray, phi: np.ndarray,
     assert phi.shape[1] == len(r_grid), \
         f'Second axis of f does not have the same length as r grid : {phi.shape}[1] != {len(r_grid)}'
 
+    if phi.dtype == np.complex128:
+        phi = np.real(phi)
+
     if method == 'sum':
         # point-wise multiplication
         f_phi = np.multiply(f, phi)

--- a/pygyro/diagnostics/diagnostic_collector.py
+++ b/pygyro/diagnostics/diagnostic_collector.py
@@ -50,14 +50,14 @@ class DiagnosticCollector:
 
         Parameters
         ----------
-        f : Grid
-            The distribution function
+            f : Grid
+                The distribution function
 
-        phi : Grid
-            The electric potential
+            phi : Grid
+                The electric potential
 
-        t : float
-            The current time
+            t : float
+                The current time
         """
         ti = t//self.dt
         idx = ti % self.saveStep

--- a/pygyro/tools/getSlice.py
+++ b/pygyro/tools/getSlice.py
@@ -11,16 +11,16 @@ def get_grid_slice(foldername, tEnd, z_idx=None, v_idx=None):
 
     Parameters
     ----------
-    foldername : str
-                 The folder containing the simulation
-    tEnd       : int
-                 The time which should be examined to obtain the slice
-    z_idx      : int
-                 The index of the slice in the z direction
-                 Default : 0
-    v_idx      : int
-                 The index of the slice in the v direction
-                 Default : nv//2
+        foldername : str
+            The folder containing the simulation
+        tEnd: int
+            The time which should be examined to obtain the slice
+        z_id : int
+            The index of the slice in the z direction
+            Default : 0
+        v_idx : int
+            The index of the slice in the v direction
+            Default : nv//2
     """
 
     assert (len(foldername) > 0)
@@ -64,16 +64,16 @@ def get_flux_surface_grid_slice(foldername, tEnd, r_idx=None, v_idx=None):
 
     Parameters
     ----------
-    foldername : str
-                 The folder containing the simulation
-    tEnd       : int
-                 The time which should be examined to obtain the slice
-    r_idx      : int
-                 The index of the slice in the r direction
-                 Default : nr//2
-    v_idx      : int
-                 The index of the slice in the v direction
-                 Default : nv//2
+        foldername : str
+            The folder containing the simulation
+        tEnd : int
+            The time which should be examined to obtain the slice
+        r_idx : int
+            The index of the slice in the r direction
+            Default : nr//2
+        v_idx : int
+            The index of the slice in the v direction
+            Default : nv//2
     """
 
     assert (len(foldername) > 0)


### PR DESCRIPTION
- Add specific diagnostics for the conservation properties of the poloidal advection step with Arakawa method: integral of $f$ and $f^2$ and the energy. Saved are these quantities before and after the step and their difference.
- Change default time integrator back to `explicit=False` in order for the tests to pass.
- Cosmetic changes and renaming in some files